### PR TITLE
Minor fixes for outdated moodle deploys

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ if 'pydevd' in sys.modules:
     print('[RUNNING IN DEBUG-MODE!]')
 
 parser = argparse.ArgumentParser(
-    description=('Moodle Donwlaoder 2 helps you download all the course' +
+    description=('Moodle Downlaoder 2 helps you download all the course' +
                  ' files  of your Moodle account.'))
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--init', action='store_true',
@@ -320,6 +320,7 @@ use_sso = args.sso
 storage_path = args.path
 skip_cert_verify = args.skip_cert_verify
 without_downloading_files = args.without_downloading_files
+
 
 if args.init:
     run_init(storage_path, use_sso, skip_cert_verify)

--- a/moodle_connector/login_helper.py
+++ b/moodle_connector/login_helper.py
@@ -17,7 +17,8 @@ def obtain_login_token(username: str, password: str, moodle_domain: str,
     }
 
     response = RequestHelper(moodle_domain, moodle_path,
-                             skip_cert_verify).get_login(login_data)
+                             skip_cert_verify=skip_cert_verify)\
+        .get_login(login_data)
 
     if "token" not in response:
         # = we didn't get an error page (checked by the RequestHelper) but

--- a/moodle_connector/request_helper.py
+++ b/moodle_connector/request_helper.py
@@ -12,11 +12,11 @@ class RequestHelper:
     """
 
     def __init__(self, moodle_domain: str, moodle_path: str = '/',
-                 token: str = '', skip_verify_cert=False):
+                 token: str = '', skip_cert_verify=False):
         """
         Opens a connection to the Moodle system
         """
-        if skip_verify_cert:
+        if skip_cert_verify:
             context = ssl._create_unverified_context()
         else:
             context = ssl._create_default_https_context()


### PR DESCRIPTION
Fixed typo in help dialog
Fixed mistake in login_helper.obtain_login_token that would make the ignore
the --skip_cert_verify flag